### PR TITLE
Fix small typo on ansible.cfg

### DIFF
--- a/how-to-use-these-roles.md
+++ b/how-to-use-these-roles.md
@@ -25,7 +25,7 @@ The `requirements.yml` file is a list of roles, for example:
 These roles are typically installed in `~/.ansible/roles/`. You can configure Ansible to look somewhere else though, for example this `ansible.cfg` stores the roles "locally", in the same directory where the ansible.cfg is found:
 
 ```ini
-[default]
+[defaults]
 roles_path = roles
 ```
 


### PR DESCRIPTION
I'm a complete ansible newbie and I started with this repo.

ansible-galaxy was ignoring ansible.cfg and this typo was the culprit.

Thanks for providing the documentation :)